### PR TITLE
chore: migrate accessibility audit github-script to v8

### DIFF
--- a/.github/workflows/accessibility-audit.yml
+++ b/.github/workflows/accessibility-audit.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Create or update GitHub issues for violations
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary
- update actions/github-script from v7 to v8 in accessibility-audit workflow

## Why
Align workflow with Node 24-compatible JavaScript action runtime.

## Validation
- confirmed no actions/github-script@v7 remains in this workflow